### PR TITLE
Change test mode setting to bool and send value "1" in request.

### DIFF
--- a/src/Vendr.PaymentProviders.Dibs/DibsMode.cs
+++ b/src/Vendr.PaymentProviders.Dibs/DibsMode.cs
@@ -1,8 +1,0 @@
-namespace Vendr.PaymentProviders.Dibs
-{
-    public enum DibsMode
-    {
-        Live,
-        Test
-    }
-}

--- a/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
@@ -79,7 +79,7 @@ namespace Vendr.PaymentProviders.Dibs
                     .WithInput("callbackurl", callbackUrl)
                     .WithInputIf("capturenow", settings.Capture, "yes")
                     .WithInputIf("calcfee", settings.CalcFee, "yes")
-                    .WithInputIf("test", settings.Mode == DibsMode.Test, "yes")
+                    .WithInputIf("test", settings.TestMode, "1")
                     .WithInput("md5key", md5Hash)
             };
         }

--- a/src/Vendr.PaymentProviders.Dibs/DibsSettings.cs
+++ b/src/Vendr.PaymentProviders.Dibs/DibsSettings.cs
@@ -64,9 +64,9 @@ namespace Vendr.PaymentProviders.Dibs
             SortOrder = 1200)]
         public bool Capture { get; set; }
 
-        [PaymentProviderSetting(Name = "Mode",
-            Description = "Set whether to process payments in live or test mode.",
+        [PaymentProviderSetting(Name = "Test Mode",
+            Description = "Set whether to process payments in test mode.",
             SortOrder = 10000)]
-        public DibsMode Mode { get; set; }
+        public bool TestMode { get; set; }
     }
 }

--- a/src/Vendr.PaymentProviders.Dibs/Vendr.PaymentProviders.Dibs.csproj
+++ b/src/Vendr.PaymentProviders.Dibs/Vendr.PaymentProviders.Dibs.csproj
@@ -89,7 +89,6 @@
   <ItemGroup>
     <Compile Include="DibsLang.cs" />
     <Compile Include="DibsPaymentProvider.cs" />
-    <Compile Include="DibsMode.cs" />
     <Compile Include="DibsSettings.cs" />
     <Compile Include="ISO4217.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Since test mode only has a value "1" and if the parameter has another value or is omitted, the payment is not in test mode.

I think in most cases it in fine the test mode is a boolean and presented as a toggle in the backoffice UI. I think most payment providers only have the option to enable or disable test mode. If some payment providers have more complex options/modes it could have a enum (dropdown) for this specific need.

![image](https://user-images.githubusercontent.com/2919859/76079170-67dc7d80-5fa4-11ea-9938-53720265387a.png)

According to the documentation the value should be "1" instead of "yes" (I guess this was just a copy/paste from one of the other paramenters).
https://tech.dibspayment.com/D2/Hosted/Input_parameters/Standard