### PR TITLE
Pass in paytype parameter from settings pay types.

### DIFF
--- a/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
@@ -83,7 +83,7 @@ namespace Vendr.PaymentProviders.Dibs
                     .WithInput("accepturl", continueUrl)
                     .WithInput("cancelurl", cancelUrl)
                     .WithInput("callbackurl", callbackUrl)
-                    .WithInputIf("paytype", payTypes.Length > 0, string.Join(",", payTypes))
+                    .WithInputIf("paytype", payTypes?.Length > 0, string.Join(",", payTypes))
                     .WithInputIf("capturenow", settings.Capture, "yes")
                     .WithInputIf("calcfee", settings.CalcFee, "yes")
                     .WithInputIf("test", settings.Mode == DibsMode.Test, "yes")

--- a/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Web;
@@ -63,6 +64,11 @@ namespace Vendr.PaymentProviders.Dibs
             var strCurrency = ISO4217.Codes[currency.Code.ToUpperInvariant()].ToString(CultureInfo.InvariantCulture);
             var orderAmount = (order.TotalPrice.Value.WithTax * 100M).ToString("0", CultureInfo.InvariantCulture);
 
+            var payTypes = settings.PayTypes?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                                             .Where(x => !string.IsNullOrWhiteSpace(x))
+                                             .Select(s => s.Trim())
+                                             .ToArray();
+
             // MD5(key2 + MD5(key1 + "merchant=<merchant>&orderid=<orderid> &currency=<cur>&amount=<amount>"))
             var md5Check = $"merchant={settings.MerchantId}&orderid={order.OrderNumber}&currency={strCurrency}&amount={orderAmount}";
             var md5Hash = GetMD5Hash(settings.MD5Key2 + GetMD5Hash(settings.MD5Key1 + md5Check));
@@ -77,6 +83,7 @@ namespace Vendr.PaymentProviders.Dibs
                     .WithInput("accepturl", continueUrl)
                     .WithInput("cancelurl", cancelUrl)
                     .WithInput("callbackurl", callbackUrl)
+                    .WithInputIf("paytype", payTypes.Length > 0, string.Join(",", payTypes))
                     .WithInputIf("capturenow", settings.Capture, "yes")
                     .WithInputIf("calcfee", settings.CalcFee, "yes")
                     .WithInputIf("test", settings.Mode == DibsMode.Test, "yes")


### PR DESCRIPTION
At the moment it is possible to define pay types in Dibs payment provider settings. However this isn't used. This PR pass in these values. If the field it empty it doesn't set the parameter and all available payment methods for the Dibs D2 account will be shown.