### PR TITLE
Fix payment status in CancelPayment

### DIFF
--- a/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
@@ -216,7 +216,7 @@ namespace Vendr.PaymentProviders.Dibs
                         TransactionInfo = new TransactionInfoUpdate()
                         {
                             TransactionId = order.TransactionInfo.TransactionId,
-                            PaymentStatus = PaymentStatus.Captured
+                            PaymentStatus = PaymentStatus.Cancelled
                         }
                     };
                 }


### PR DESCRIPTION
Just a minor issue in `CancelPayment` method, where it set payment status `Captured` instead of `Cancelled`.