### PR TITLE
Amount to/from minor units

### DIFF
--- a/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Dibs/DibsPaymentProvider.cs
@@ -61,7 +61,7 @@ namespace Vendr.PaymentProviders.Dibs
             }
 
             var strCurrency = Iso4217.CurrencyCodes[currency.Code.ToUpperInvariant()].ToString(CultureInfo.InvariantCulture);
-            var orderAmount = (order.TotalPrice.Value.WithTax * 100M).ToString("0", CultureInfo.InvariantCulture);
+            var orderAmount = AmountToMinorUnits(order.TotalPrice.Value.WithTax).ToString("0", CultureInfo.InvariantCulture);
 
             var payTypes = settings.PayTypes?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                    .Where(x => !string.IsNullOrWhiteSpace(x))
@@ -117,7 +117,7 @@ namespace Vendr.PaymentProviders.Dibs
                     {
                         TransactionInfo = new TransactionInfo
                         {
-                            AmountAuthorized = totalAmount / 100M,
+                            AmountAuthorized = AmountFromMinorUnits((long)totalAmount),
                             TransactionId = transaction,
                             PaymentStatus = !captured ? PaymentStatus.Authorized : PaymentStatus.Captured
                         }
@@ -237,7 +237,7 @@ namespace Vendr.PaymentProviders.Dibs
         {
             try
             {
-                var strAmount = (order.TransactionInfo.AmountAuthorized.Value * 100M).ToString("0", CultureInfo.InvariantCulture);
+                var strAmount = AmountToMinorUnits(order.TransactionInfo.AmountAuthorized.Value).ToString("0", CultureInfo.InvariantCulture);
 
                 // MD5(key2 + MD5(key1 + "merchant=<merchant>&orderid=<orderid>&transact=<transact>&amount=<amount>")) 
                 var md5Check = $"merchant={settings.MerchantId}&orderid={order.OrderNumber}&transact={order.TransactionInfo.TransactionId}&amount={strAmount}";
@@ -294,7 +294,7 @@ namespace Vendr.PaymentProviders.Dibs
                 }
 
                 var strCurrency = Iso4217.CurrencyCodes[currency.Code.ToUpperInvariant()].ToString(CultureInfo.InvariantCulture);
-                var strAmount = (order.TransactionInfo.AmountAuthorized.Value * 100M).ToString("0", CultureInfo.InvariantCulture);
+                var strAmount = AmountToMinorUnits(order.TransactionInfo.AmountAuthorized.Value).ToString("0", CultureInfo.InvariantCulture);
 
                 // MD5(key2 + MD5(key1 + "merchant=<merchant>&orderid=<orderid>&transact=<transact>&amount=<amount>")) 
                 var md5Check = $"merchant={settings.MerchantId}&orderid={order.OrderNumber}&transact={order.TransactionInfo.TransactionId}&amount={strAmount}";

--- a/src/Vendr.PaymentProviders.Dibs/Vendr.PaymentProviders.Dibs.csproj
+++ b/src/Vendr.PaymentProviders.Dibs/Vendr.PaymentProviders.Dibs.csproj
@@ -46,8 +46,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OD.Licensing, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OD.Licensing.0.1.0\lib\net45\OD.Licensing.dll</HintPath>
+    <Reference Include="OD.Licensing, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OD.Licensing.0.3.2\lib\net45\OD.Licensing.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -79,11 +79,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Vendr.Core, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Vendr.Core.0.1.0-alpha0418\lib\net472\Vendr.Core.dll</HintPath>
+    <Reference Include="Vendr.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vendr.Core.1.0.0\lib\net472\Vendr.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Vendr.Core.Web, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Vendr.Core.Web.0.1.0-alpha0418\lib\net472\Vendr.Core.Web.dll</HintPath>
+    <Reference Include="Vendr.Core.Web, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vendr.Core.Web.1.0.0\lib\net472\Vendr.Core.Web.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Vendr.PaymentProviders.Dibs/packages.config
+++ b/src/Vendr.PaymentProviders.Dibs/packages.config
@@ -7,8 +7,8 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
-  <package id="OD.Licensing" version="0.1.0" targetFramework="net472" />
+  <package id="OD.Licensing" version="0.3.2" targetFramework="net472" />
   <package id="Portable.BouncyCastle" version="1.8.5" targetFramework="net472" />
-  <package id="Vendr.Core" version="0.1.0-alpha0418" targetFramework="net472" />
-  <package id="Vendr.Core.Web" version="0.1.0-alpha0418" targetFramework="net472" />
+  <package id="Vendr.Core" version="1.0.0" targetFramework="net472" />
+  <package id="Vendr.Core.Web" version="1.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Just upgraded to Vendr v1.0.0 as minimum dependency and re-used the methods `AmountToMinorUnits` and `AmountFromMinorUnits`.